### PR TITLE
Allow for picking hash (version) for blockly

### DIFF
--- a/npm-scripts/generate.sh
+++ b/npm-scripts/generate.sh
@@ -15,7 +15,7 @@ mkdir tmp
 cd tmp
 git clone https://github.com/google/blockly.git
 
-if [ -n $githash ]
+if [ -n "$githash" ]
 then
 	cd blockly
 	git checkout $githash

--- a/npm-scripts/generate.sh
+++ b/npm-scripts/generate.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Allow user to pick what commit hash they want to checkout
+echo Enter a commit hash or enter nothing to use the latest version of blockly
+read githash
+
 # Clear tmp directory if it exist
 rm -rf tmp
 
@@ -10,9 +14,6 @@ rm -rf dist
 mkdir tmp
 cd tmp
 git clone https://github.com/google/blockly.git
-
-echo Enter a commit hash or enter nothing to use the latest version of blockly
-read githash
 
 if [ -n $githash ]
 then

--- a/npm-scripts/generate.sh
+++ b/npm-scripts/generate.sh
@@ -11,6 +11,16 @@ mkdir tmp
 cd tmp
 git clone https://github.com/google/blockly.git
 
+echo Enter a commit hash or enter nothing to use the latest version of blockly
+read githash
+
+if [ -n $githash ]
+then
+	cd blockly
+	git checkout $githash
+	cd ..
+fi
+
 # move to blockly core directory
 cd blockly/core
 


### PR DESCRIPTION
This allows picking of the hash so that the user can specify what has (version) of Blockly they want to use since Google clearly hates version numbering...