### PR TITLE
Improves building by clearing out some directories

### DIFF
--- a/npm-scripts/generate.sh
+++ b/npm-scripts/generate.sh
@@ -1,4 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Clear tmp directory if it exist
+rm -rf tmp
+
+# Clear dist directort if it exist
+rm -rf dist
 
 #get latest blockly code
 mkdir tmp

--- a/npm-scripts/generate.sh
+++ b/npm-scripts/generate.sh
@@ -3,7 +3,7 @@
 # Clear tmp directory if it exist
 rm -rf tmp
 
-# Clear dist directort if it exist
+# Clear dist directory if it exist
 rm -rf dist
 
 #get latest blockly code


### PR DESCRIPTION
This fix removes the dist and tmp folder before building to prevent issues when creating these directories. This could also have been fixed by `mkdir -p` but it's better practice to clear out the directories to really insure a fresh build.